### PR TITLE
Add remaining tests for simple skills & initial tests for lava envs

### DIFF
--- a/nle_code_wrapper/bot/bot.py
+++ b/nle_code_wrapper/bot/bot.py
@@ -34,14 +34,18 @@ class Bot:
     @property
     def message(self):
         return bytes(self.last_obs["message"]).decode("latin-1").rstrip("\x00")
-    
+
     @property
     def inv_glyphs(self):
         return self.last_obs["inv_glyphs"]
-    
-    @property 
+
+    @property
     def inv_letters(self):
         return self.last_obs["inv_letters"]
+
+    @property
+    def inv_oclasses(self):
+        return self.last_obs["inv_oclasses"]
 
     @property
     def cursor(self):

--- a/nle_code_wrapper/bot/bot.py
+++ b/nle_code_wrapper/bot/bot.py
@@ -34,6 +34,14 @@ class Bot:
     @property
     def message(self):
         return bytes(self.last_obs["message"]).decode("latin-1").rstrip("\x00")
+    
+    @property
+    def inv_glyphs(self):
+        return self.last_obs["inv_glyphs"]
+    
+    @property 
+    def inv_letters(self):
+        return self.last_obs["inv_letters"]
 
     @property
     def cursor(self):

--- a/nle_code_wrapper/bot/level.py
+++ b/nle_code_wrapper/bot/level.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 import numpy as np
-from nle_utils.glyph import SHOP, C, G
+from nle_utils.glyph import SHOP, C, G, SS
 
 from nle_code_wrapper.utils import utils
 
@@ -60,6 +60,19 @@ class Level:
         self.seen[mask] = True
         self.objects[mask] = glyphs[mask]
         self.walkable[mask] = False
+
+        # NOTE: adjust for levitation (1024 in blstats)
+        # TODO: not sure if this is the best way to check
+        if blstats.prop_mask & 0b10000000000:
+            mask = utils.isin(glyphs, [SS.S_lava])
+            self.walkable[mask] = True
+            self.seen[mask] = True
+        else:
+            # make sure to turn back off when we are not levitating
+            mask = utils.isin(glyphs, [SS.S_lava])
+            self.walkable[mask] = False
+            self.seen[mask] = False
+
 
         self.was_on[blstats.y, blstats.x] = True
 

--- a/nle_code_wrapper/bot/level.py
+++ b/nle_code_wrapper/bot/level.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 
 import numpy as np
-from nle_utils.glyph import SHOP, C, G, SS
+from nle import nethack
+from nle_utils.glyph import SHOP, SS, C, G
 
 from nle_code_wrapper.utils import utils
 
@@ -62,8 +63,7 @@ class Level:
         self.walkable[mask] = False
 
         # NOTE: adjust for levitation (1024 in blstats)
-        # TODO: not sure if this is the best way to check
-        if blstats.prop_mask & 0b10000000000:
+        if blstats.prop_mask & nethack.BL_MASK_LEV:
             mask = utils.isin(glyphs, [SS.S_lava])
             self.walkable[mask] = True
             self.seen[mask] = True
@@ -72,7 +72,6 @@ class Level:
             mask = utils.isin(glyphs, [SS.S_lava])
             self.walkable[mask] = False
             self.seen[mask] = False
-
 
         self.was_on[blstats.y, blstats.x] = True
 

--- a/nle_code_wrapper/bot/strategy/strategies/__init__.py
+++ b/nle_code_wrapper/bot/strategy/strategies/__init__.py
@@ -9,6 +9,7 @@ from nle_code_wrapper.bot.strategy.strategies.pray import pray
 from nle_code_wrapper.bot.strategy.strategies.random_move import random_move
 from nle_code_wrapper.bot.strategy.strategies.search import search
 from nle_code_wrapper.bot.strategy.strategies.smart_fight import smart_fight_strategy
+from nle_code_wrapper.bot.strategy.strategies.quaff import quaff_potion_from_inv
 
 __all__ = [
     explore,
@@ -25,4 +26,5 @@ __all__ = [
     smart_fight_strategy,
     pickup_items,
     goto_items,
+    quaff_potion_from_inv
 ]

--- a/nle_code_wrapper/bot/strategy/strategies/quaff.py
+++ b/nle_code_wrapper/bot/strategy/strategies/quaff.py
@@ -1,0 +1,25 @@
+from nle.nethack import actions as A
+from nle_utils.glyph import G
+
+from nle_code_wrapper.bot.bot import Bot
+from nle_code_wrapper.bot.strategy import State, Strategy
+
+
+@Strategy.wrap
+def quaff_potion_from_inv(bot: "Bot"):
+    inv_glyphs = bot.inv_glyphs
+    inv_letters = bot.inv_letters
+
+    # find the first potion in the inventory
+    potion_char = None
+    for char, glyph in zip(inv_letters, inv_glyphs):
+        if glyph in G.POTION_CLASS:
+            potion_char = char
+            break
+
+    if potion_char is None:
+        yield False
+    else:
+        bot.step(A.Command.QUAFF)
+        bot.step(potion_char)
+        yield True

--- a/nle_code_wrapper/bot/strategy/strategies/quaff.py
+++ b/nle_code_wrapper/bot/strategy/strategies/quaff.py
@@ -10,12 +10,11 @@ def quaff_potion_from_inv(bot: "Bot"):
     inv_glyphs = bot.inv_glyphs
     inv_letters = bot.inv_letters
 
-    # find the first potion in the inventory
+    # find the last potion in the inventory
     potion_char = None
     for char, glyph in zip(inv_letters, inv_glyphs):
         if glyph in G.POTION_CLASS:
             potion_char = char
-            break
 
     if potion_char is None:
         yield False

--- a/tests/minihack/test_lava.py
+++ b/tests/minihack/test_lava.py
@@ -1,0 +1,103 @@
+from functools import partial
+
+import pytest
+from nle.nethack import actions as A
+from nle_utils.glyph import G
+from nle_utils.play import play
+
+from nle_code_wrapper.bot.bot import Bot
+from nle_code_wrapper.bot.strategy import Strategy
+from nle_code_wrapper.bot.strategy.strategies import (
+    goto_stairs,
+    quaff_potion_from_inv,
+)
+from nle_code_wrapper.envs.minihack.play_minihack import parse_minihack_args
+from nle_code_wrapper.utils import utils
+
+
+@Strategy.wrap
+def lava_strategy(bot: "Bot"):
+    goto_ring_strat = goto(bot, G.RING_CLASS)
+    goto_potion_strat = goto(bot, G.POTION_CLASS)
+    pickup_strat = pickup(bot)
+    quaff_potion_from_inv_strat = quaff_potion_from_inv(bot)
+    put_on_ring_from_inv_strat = put_on_ring_from_inv(bot)
+    goto_stairs_strat = goto_stairs(bot)
+
+    while True:
+        goto_ring_strat()
+        goto_potion_strat()
+        pickup_strat()
+        if put_on_ring_from_inv_strat():
+            pass
+        else:
+            quaff_potion_from_inv_strat()
+        goto_stairs_strat()
+        yield
+
+@Strategy.wrap
+def pickup(bot: "Bot"):
+    bot.step(A.Command.PICKUP)
+    
+    if bot.message.strip() == "":
+        yield False
+    else:
+        yield True
+
+@Strategy.wrap
+def goto(bot: "Bot", where):
+    coords = utils.coords(bot.glyphs, where)
+    distances = bot.pathfinder.distances(bot.entity.position)
+
+    position = min(
+        (e for e in coords if e in distances),
+        key=lambda e: distances[e],
+        default=None,
+    )
+
+    if position:
+        bot.pathfinder.goto(position)
+        yield True
+    else:
+        yield False
+
+@Strategy.wrap
+def put_on_ring_from_inv(bot: "Bot"):
+    inv_glyphs = bot.inv_glyphs
+    inv_letters = bot.inv_letters
+
+    # find the first potion in the inventory
+    ring_char = None
+    for char, glyph in zip(inv_letters, inv_glyphs):
+        if glyph in G.RING_CLASS:
+            ring_char = char
+            break
+
+    if ring_char is None:
+        yield False
+    else:
+        bot.step(A.Command.PUTON)
+        bot.step(ring_char)
+        bot.type_text('l') # indicates left ring finger - not sure if this matters
+        yield True
+
+
+@pytest.mark.usefixtures("register_components")
+class TestMazewalkMapped(object):
+    @pytest.mark.parametrize(
+        "env",
+        [
+            "MiniHack-LavaCross-Levitate-Potion-Inv-Full-v0",
+            "MiniHack-LavaCross-Levitate-Ring-Inv-Full-v0",
+            "MiniHack-LavaCross-Levitate-Potion-Pickup-Full-v0",
+            "MiniHack-LavaCross-Levitate-Ring-Pickup-Full-v0",
+        ],
+    )
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_lava(self, env, seed):
+        # TODO: for some of the variants there are monsters which have to be dealt with
+        # TODO: for some of the seeds there are items already worn, which have to be taken off
+        cfg = parse_minihack_args(argv=[f"--env={env}", "--no-render", f"--seed={seed}"])
+        cfg.strategies = [lava_strategy]
+        status = play(cfg)
+        assert status["end_status"].name == "TASK_SUCCESSFUL"

--- a/tests/minihack/test_lava.py
+++ b/tests/minihack/test_lava.py
@@ -1,16 +1,14 @@
 from functools import partial
 
 import pytest
+from nle import nethack
 from nle.nethack import actions as A
 from nle_utils.glyph import G
 from nle_utils.play import play
 
 from nle_code_wrapper.bot.bot import Bot
 from nle_code_wrapper.bot.strategy import Strategy
-from nle_code_wrapper.bot.strategy.strategies import (
-    goto_stairs,
-    quaff_potion_from_inv,
-)
+from nle_code_wrapper.bot.strategy.strategies import goto_stairs, quaff_potion_from_inv
 from nle_code_wrapper.envs.minihack.play_minihack import parse_minihack_args
 from nle_code_wrapper.utils import utils
 
@@ -35,14 +33,16 @@ def lava_strategy(bot: "Bot"):
         goto_stairs_strat()
         yield
 
+
 @Strategy.wrap
 def pickup(bot: "Bot"):
     bot.step(A.Command.PICKUP)
-    
+
     if bot.message.strip() == "":
         yield False
     else:
         yield True
+
 
 @Strategy.wrap
 def goto(bot: "Bot", where):
@@ -61,25 +61,28 @@ def goto(bot: "Bot", where):
     else:
         yield False
 
+
 @Strategy.wrap
 def put_on_ring_from_inv(bot: "Bot"):
-    inv_glyphs = bot.inv_glyphs
     inv_letters = bot.inv_letters
+    inv_oclasses = bot.inv_oclasses
 
-    # find the first potion in the inventory
-    ring_char = None
-    for char, glyph in zip(inv_letters, inv_glyphs):
-        if glyph in G.RING_CLASS:
-            ring_char = char
-            break
+    ring_letters = inv_letters[inv_oclasses == nethack.RING_CLASS]
 
-    if ring_char is None:
-        yield False
-    else:
+    # find the ring of levitation
+    levitation = False
+    for ring_char in ring_letters:
         bot.step(A.Command.PUTON)
         bot.step(ring_char)
-        bot.type_text('l') # indicates left ring finger - not sure if this matters
-        yield True
+        bot.type_text("l")  # indicates left ring finger - not sure if this matters
+
+        if bot.blstats.prop_mask & nethack.BL_MASK_LEV:
+            levitation = True
+            break
+        else:
+            bot.step(A.Command.REMOVE)
+
+    yield levitation
 
 
 @pytest.mark.usefixtures("register_components")
@@ -93,10 +96,9 @@ class TestMazewalkMapped(object):
             "MiniHack-LavaCross-Levitate-Ring-Pickup-Full-v0",
         ],
     )
-    @pytest.mark.parametrize("seed", [0, 1, 2])
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
     def test_lava(self, env, seed):
         # TODO: for some of the variants there are monsters which have to be dealt with
-        # TODO: for some of the seeds there are items already worn, which have to be taken off
         cfg = parse_minihack_args(argv=[f"--env={env}", "--no-render", f"--seed={seed}"])
         cfg.strategies = [lava_strategy]
         status = play(cfg)

--- a/tests/minihack/test_mini.py
+++ b/tests/minihack/test_mini.py
@@ -106,3 +106,69 @@ class TestMazewalkMapped(object):
         cfg.strategies = [open_doors_kick, explore, goto_stairs]
         status = play(cfg)
         assert status["end_status"].name == "TASK_SUCCESSFUL"
+
+    @pytest.mark.parametrize("env", ["MiniHack-LockedDoor-v0"])
+    @pytest.mark.parametrize("seed", [0])
+    def test_mini_locked_dynamic(self, env, seed):
+        cfg = parse_minihack_args(argv=[f"--env={env}", "--no-render", f"--seed={seed}"])
+        bot = Bot(cfg)
+
+        bot.strategy(open_doors_kick)
+        bot.strategy(explore)
+        bot.strategy(goto_stairs)
+
+        cfg.strategies = [open_doors_kick, explore, goto_stairs]
+        status = play(cfg)
+        assert status["end_status"].name == "TASK_SUCCESSFUL"
+
+    @pytest.mark.parametrize(
+        "env, where, action",
+        [
+            ("MiniHack-Eat-v0", G.FOOD_OBJECTS, partial(make_action_and_confirm, command=A.Command.EAT)),
+            ("MiniHack-Pray-v0", G.ALTAR, partial(make_action_and_confirm, command=A.Command.PRAY)),
+            ("MiniHack-Sink-v0", G.SINK, partial(make_action_and_confirm, command=A.Command.QUAFF)),
+            ("MiniHack-Read-v0", G.SCROLL_CLASS, partial(pickup_and_use_item, command=A.Command.READ)),
+            ("MiniHack-Zap-v0", G.WAND_CLASS, partial(pickup_and_use_item, command=A.Command.ZAP)),
+            (
+                "MiniHack-PutOn-v0",
+                frozenset.union(G.AMULET_CLASS, G.RING_CLASS),
+                partial(pickup_and_use_item, command=A.Command.PUTON),
+            ),
+            ("MiniHack-Wear-v0", G.ARMOR_CLASS, partial(pickup_and_use_item, command=A.Command.WEAR)),
+            ("MiniHack-Wield-v0", G.WEAPON_CLASS, partial(pickup_and_use_item, command=A.Command.WIELD)),
+        ],
+    )
+    @pytest.mark.parametrize("seed", [100])
+    def test_mini_dynamic(self, env, where, action, seed):
+        # TODO: for some of the variants there are monsters which have to be dealt with
+        # TODO: for some of the seeds there are items already worn, which have to be taken off
+        cfg = parse_minihack_args(argv=[f"--env={env}", "--no-render", f"--seed={seed}"])
+        cfg.strategies = [partial(general_mini, where=where, action=action)]
+        status = play(cfg)
+        assert status["end_status"].name == "TASK_SUCCESSFUL"
+
+    @pytest.mark.parametrize(
+        "env, where, action",
+        [
+            ("MiniHack-Eat-Distr-v0", G.FOOD_OBJECTS, partial(make_action_and_confirm, command=A.Command.EAT)),
+            ("MiniHack-Pray-Distr-v0", G.ALTAR, partial(make_action_and_confirm, command=A.Command.PRAY)),
+            ("MiniHack-Sink-Distr-v0", G.SINK, partial(make_action_and_confirm, command=A.Command.QUAFF)),
+            ("MiniHack-Read-Distr-v0", G.SCROLL_CLASS, partial(pickup_and_use_item, command=A.Command.READ)),
+            ("MiniHack-Zap-Distr-v0", G.WAND_CLASS, partial(pickup_and_use_item, command=A.Command.ZAP)),
+            (
+                "MiniHack-PutOn-Distr-v0",
+                frozenset.union(G.AMULET_CLASS, G.RING_CLASS),
+                partial(pickup_and_use_item, command=A.Command.PUTON),
+            ),
+            ("MiniHack-Wear-Distr-v0", G.ARMOR_CLASS, partial(pickup_and_use_item, command=A.Command.WEAR)),
+            ("MiniHack-Wield-Distr-v0", G.WEAPON_CLASS, partial(pickup_and_use_item, command=A.Command.WIELD)),
+        ],
+    )
+    @pytest.mark.parametrize("seed", [100])
+    def test_mini_distract(self, env, where, action, seed):
+        # TODO: for some of the variants there are monsters which have to be dealt with
+        # TODO: for some of the seeds there are items already worn, which have to be taken off
+        cfg = parse_minihack_args(argv=[f"--env={env}", "--no-render", f"--seed={seed}"])
+        cfg.strategies = [partial(general_mini, where=where, action=action)]
+        status = play(cfg)
+        assert status["end_status"].name == "TASK_SUCCESSFUL"


### PR DESCRIPTION
**Summary of changes**
1. Added `inv_glyphs` and `inv_letters` as properties on the bot so inventory features can be accessed from the strategies.
2. Added an exception rule in the `Level:update` function so that after levitation lava glyphs are marked as walkable. This is so that the shortest path calculation doesn't fail (i.e. otherwise it'll think there is no paths available, while there is since we can float over the lava).
3. Added a new strategy that drinks the most recently added potion in the inventory. Taking the last is important since sometimes the agent starts with other potions already, and it turns out sometimes those potions are even harmful. There might be a better mechanism here to grab the right potion, but so far always grabbing the last one seems to work. Open to other suggestions though! 
4. Added strategies and tests for some of the core lava environments, which should all pass. 
5. Added additional tests for some of the more advanced simple skills (see `test_mini`). 

@BartekCupial since I'm just starting out using this codebase I might have messed up here and there as to where to best put things in the repo or other formatting things (are you using any formatters currently that I should be running?). Feel free to let me know and I'm happy to make any changes necessary! 