### PR TITLE
pass arguments strategy

### DIFF
--- a/nle_code_wrapper/bot/pathfinder/pathfinder.py
+++ b/nle_code_wrapper/bot/pathfinder/pathfinder.py
@@ -50,6 +50,20 @@ class Pathfinder:
         result = self.search.astar(start, goal)
         return result
 
+    def random_move(self):
+        movements = [
+            A.CompassDirection.N,
+            A.CompassDirection.S,
+            A.CompassDirection.E,
+            A.CompassDirection.W,
+            A.CompassDirection.NE,
+            A.CompassDirection.SE,
+            A.CompassDirection.NW,
+            A.CompassDirection.SW,
+        ]
+        action = movements[np.random.choice(len(movements))]
+        self.bot.step(action)
+
     def direction(self, pos):
         bot_pos = self.bot.entity.position
         dir = calc_direction(bot_pos[0], bot_pos[1], pos[0], pos[1])

--- a/nle_code_wrapper/bot/strategies/__init__.py
+++ b/nle_code_wrapper/bot/strategies/__init__.py
@@ -1,6 +1,7 @@
 from nle_code_wrapper.bot.strategies.explore import explore
 from nle_code_wrapper.bot.strategies.explore_items import explore_items
 from nle_code_wrapper.bot.strategies.fight_monster import fight_all_monsters, fight_closest_monster
+from nle_code_wrapper.bot.strategies.goto import goto
 from nle_code_wrapper.bot.strategies.goto_items import goto_items
 from nle_code_wrapper.bot.strategies.goto_stairs import goto_stairs
 from nle_code_wrapper.bot.strategies.open_doors import open_doors, open_doors_key, open_doors_kick
@@ -25,4 +26,5 @@ __all__ = [
     pickup_items,
     goto_items,
     quaff_potion_from_inv,
+    goto,
 ]

--- a/nle_code_wrapper/bot/strategies/goto.py
+++ b/nle_code_wrapper/bot/strategies/goto.py
@@ -1,0 +1,6 @@
+from nle_code_wrapper.bot import Bot
+
+
+def goto(bot: "Bot", y: int, x: int):
+    position = (y, x)
+    return bot.pathfinder.goto(position)

--- a/nle_code_wrapper/wrappers/nle_code_wrapper.py
+++ b/nle_code_wrapper/wrappers/nle_code_wrapper.py
@@ -13,7 +13,7 @@ class NLECodeWrapper(gym.Wrapper):
 
         for strategy_func in strategies:
             self.bot.strategy(strategy_func)
-        self.action_space = gym.spaces.Discrete(len(self.bot.strategies))
+        self.action_space = gym.spaces.Discrete(100)  # TODO: Change this to the number of actions in the action space
         self.observation_space = gym.spaces.Dict(
             {"strategy_steps": gym.spaces.Box(low=0, high=255, shape=(1,)), **self.env.observation_space}
         )

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from nle_code_wrapper.envs.minihack.play_minihack import register_minihack_components
+
+
+@pytest.fixture(scope="session", autouse=True)
+def register_components():
+    register_minihack_components()

--- a/tests/strategies/test_pass_argument_strategy.py
+++ b/tests/strategies/test_pass_argument_strategy.py
@@ -1,0 +1,52 @@
+import pytest
+from nle_utils.play import play
+
+from nle_code_wrapper.bot.bot import Bot
+from nle_code_wrapper.bot.exceptions import BotFinished
+from nle_code_wrapper.bot.strategies import goto
+from nle_code_wrapper.envs.minihack.play_minihack import parse_minihack_args
+
+
+@pytest.mark.usefixtures("register_components")
+class TestMazewalkMapped(object):
+    @pytest.mark.parametrize("env", ["MiniHack-Room-5x5-v0"])
+    @pytest.mark.parametrize("seed", [0])
+    def test_goto(self, env, seed):
+        cfg = parse_minihack_args(argv=[f"--env={env}", f"--seed={seed}", "--no-render"])
+
+        def general(bot: "Bot"):
+            cur_pos = bot.entity.position
+            distances = bot.pathfinder.distances(cur_pos)
+            furthest = max(distances.items(), key=lambda s: s[1])[0]
+            goto(bot, furthest[0], furthest[1])
+            assert bot.entity.position == furthest
+            raise BotFinished
+
+        cfg.strategies = [general]
+        play(cfg)
+
+    @pytest.mark.parametrize("env", ["MiniHack-Room-5x5-v0"])
+    @pytest.mark.parametrize("seed", [0])
+    def test_pass_argument_strategy(self, env, seed):
+        cfg = parse_minihack_args(argv=[f"--env={env}", f"--seed={seed}", "--code_wrapper=True", "--no-render"])
+
+        def get_action(env, mode, obs, var=[0]):
+            cur_pos = env.bot.entity.position
+            distances = env.bot.pathfinder.distances(cur_pos)
+            furthest = max(distances.items(), key=lambda s: s[1])[0]
+
+            if var[0] == 0:
+                ret = 0
+            elif var[0] == 1:
+                ret = furthest[0]
+            elif var[0] == 2:
+                ret = furthest[1]
+            else:
+                raise BotFinished
+
+            var[0] += 1
+            return ret
+
+        cfg.strategies = [goto]
+        with pytest.raises(BotFinished):
+            play(cfg, get_action=get_action)


### PR DESCRIPTION
Changelog:
- feature: new pathfinder function, `random_move` 
- add new strategy `goto` which takes 2 arguments for y and x coordinates
- had to implement a way to pass arguments to strategies, this means that for some actions there is noop (for now we make `random_move`)
- tests for goto strategy 