### PR TITLE
monitor strategy steps

### DIFF
--- a/experiments/local.py
+++ b/experiments/local.py
@@ -24,14 +24,25 @@ config = {
     "wandb_group": "ideas-ncbr",
     "with_wandb": False,
     "decorrelate_envs_on_one_worker": False,
-    "code_wrapper": False,
+    "code_wrapper": True,
 }
 
 # params different between exps
 params_grid = [
     {
         "seed": list(range(1)),
-        "strategies": [["explore", "search", "open_doors_kick", "goto_stairs", "fight_closest_monster"]],
+        "strategies": [
+            [
+                "goto_closest_staircase_down",
+                "explore_room",
+                "explore_corridor_systematically",
+                "goto_closest_corridor",
+                "open_doors_kick",
+                "goto_closest_unexplored_room",
+                "search_corridor_for_hidden_doors",
+                "search_room_for_hidden_doors",
+            ]
+        ],
         "gamma": [0.999],
         "batch_size": [128],
         "num_workers": [4],

--- a/nle_code_wrapper/bot/bot.py
+++ b/nle_code_wrapper/bot/bot.py
@@ -114,7 +114,7 @@ class Bot:
 
         extra_stats = self.last_info.get("episode_extra_stats", {})
         new_extra_stats = {
-            "strategy_steps": self.steps,
+            "env_steps": self.steps,
             "strategy_reward": self.reward,
             "strategy_usefull": self.steps > 0,
         }
@@ -165,8 +165,8 @@ class Bot:
                     self.current_strategy = self.strategies[action]
                     self.current_args = ()
                 else:
-                    # if action is wrong do nothing, but also increment strategy_step
-                    # TODO: turn off for tests?
+                    # if action is wrong do nothing, we still should increment strategy_step
+                    # this is only relevant for multiple arguments strategies
                     self.strategy_steps += 1
             else:
                 self.current_args += (action,)
@@ -187,13 +187,14 @@ class Bot:
 
         extra_stats = self.last_info.get("episode_extra_stats", {})
         new_extra_stats = {
-            "strategy_steps": self.steps,
+            "env_steps": self.steps,
             "strategy_reward": self.reward,
             "strategy_usefull": self.steps > 0,
         }
 
         if self.terminated or self.truncated:
             new_extra_stats["success_rate"] = self.last_info["end_status"].name == "TASK_SUCCESSFUL"
+            new_extra_stats["strategy_steps"] = self.strategy_steps
 
         self.last_info["episode_extra_stats"] = {**extra_stats, **new_extra_stats}
 

--- a/nle_code_wrapper/wrappers/nle_code_wrapper.py
+++ b/nle_code_wrapper/wrappers/nle_code_wrapper.py
@@ -17,17 +17,17 @@ class NLECodeWrapper(gym.Wrapper):
             self.bot.strategy(strategy_func)
         self.action_space = gym.spaces.Discrete(len(strategies))
         self.observation_space = gym.spaces.Dict(
-            {"strategy_steps": gym.spaces.Box(low=0, high=255, shape=(1,)), **self.env.observation_space}
+            {"env_steps": gym.spaces.Box(low=0, high=255, shape=(1,)), **self.env.observation_space}
         )
 
     def reset(self, **kwargs) -> Tuple[Dict[str, ndarray], Dict[str, Any]]:
         obs, info = self.bot.reset(**kwargs)
-        obs["strategy_steps"] = np.array([info["episode_extra_stats"]["strategy_steps"]])
+        obs["env_steps"] = np.array([info["episode_extra_stats"]["env_steps"]])
 
         return obs, info
 
     def step(self, action: Union[int64, int]) -> Tuple[Dict[str, ndarray], float, bool, bool, Dict[str, Any]]:
         obs, reward, terminated, truncated, info = self.bot.strategy_step(action)
-        obs["strategy_steps"] = np.array([info["episode_extra_stats"]["strategy_steps"]])
+        obs["env_steps"] = np.array([info["episode_extra_stats"]["env_steps"]])
 
         return obs, reward, terminated, truncated, info


### PR DESCRIPTION
use new version of sample factory which handles env_steps from inner environment, renamed strategy_steps to env_steps (number of env steps in one strategy_step), added strategy_steps (total number of times strategy was executed)